### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ With the Harvest for Safari extension, you can:
 * Start and stop timers directly from the Safari toolbar.
 * Start and stop timers from to-dos in Basecamp and cards in Trello.
 
-## Download Harvest for Safari
+## Installing from Safari Extensions Gallery
 
-* Download the newest version from [Releases](https://github.com/harvesthq/harvest_for_safari/releases).
-* Double click on the downloaded **harvest_for_safari-x.y.z.safariextz**.
-* Click **Trust** in Safari to confirm downloading the extension.
-
-![Click Trust to confirm](http://cloudapp.layer22.com/1t3W1G050F3F/Screen%20Shot%202016-04-13%20at%2011.27.51.png)
+The easiest way to install Harvest for Safari is from the [Safari Extension Gallery](https://safari-extensions.apple.com/?q=Harvest%20Time%20Tracker) by simply clicking **Install Now**.

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ With the Harvest for Safari extension, you can:
 
 ## Installing from Safari Extensions Gallery
 
-The easiest way to install Harvest for Safari is from the [Safari Extension Gallery](https://safari-extensions.apple.com/?q=Harvest%20Time%20Tracker) by simply clicking **Install Now**.
+The easiest way to install Harvest for Safari is from the [Safari Extensions Gallery](https://safari-extensions.apple.com/?q=Harvest%20Time%20Tracker). Simply click **Install Now**.


### PR DESCRIPTION
@braddunbar @calinam @harvesthq/harvest-developers Hello!

Given that the extension is available from the Safari Extensions Gallery, we should point our users to the gallery instead of asking them to install by downloading the file.

I've dropped the whole section about custom installation.

The users are pointed to the search results page as I'm not sure if the URL changes whenever there's a change to the certificate (looks like the certificate ID is added at the end of the direct extension page URL).

@calinam Tagged you in case you have a better idea how to word the instructions.

Thanks!